### PR TITLE
Add verifyPassword method to GitkitClient

### DIFF
--- a/src/main/java/com/google/identitytoolkit/GitkitClient.java
+++ b/src/main/java/com/google/identitytoolkit/GitkitClient.java
@@ -176,6 +176,79 @@ public class GitkitClient {
     }
     return null;
   }
+  
+  /**
+   * Verifies the user entered password at Gitkit server.
+   *
+   * @param email The email of the user
+   * @param password The password inputed by the user
+   * @param pendingIdToken The GITKit token for the non-trusted IDP, which is to be confirmed by the user
+   * @param captchaChallenge The captcha challenge
+   * @param captchaResponse Response to the captcha
+   * @return the verify password response.
+   * @throws GitkitClientException for invalid request
+   * @throws GitkitServerException for server error
+   */
+  public VerifyPasswordResponse verifyPassword(String email, String password, String pendingIdToken,
+                                               String captchaChallenge, String captchaResponse)
+      throws GitkitClientException, GitkitServerException {
+    try {
+      JSONObject result = rpcHelper.verifyPassword(email, password, pendingIdToken, captchaChallenge, captchaResponse);
+      return new VerifyPasswordResponse(result.getString("localId"), result.getString("email"),
+                                        result.getString("displayName"), result.getString("idToken"),
+                                        result.getBoolean("registered"), result.getString("photoUrl"));
+    } catch (JSONException e) {
+      throw new GitkitServerException(e);
+    }
+  }
+
+  /**
+   * Wrapper class containing the verify password responses.
+   */
+  public class VerifyPasswordResponse {
+    private final String localId;
+    private final String email;
+    private final String displayName;
+    private final String idToken;
+    private final boolean registered;
+    private final String photoUrl;
+
+    public VerifyPasswordResponse(String localId, String email, String displayName, String idToken,
+                                  boolean registered, String photoUrl)
+    {
+        this.localId = localId;
+        this.email = email;
+        this.displayName = displayName;
+        this.idToken = idToken;
+        this.registered = registered;
+        this.photoUrl = photoUrl;
+    }
+
+    public String getLocalId() {
+        return localId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getIdToken() {
+        return idToken;
+    }
+
+    public boolean isRegistered() {
+        return registered;
+    }
+
+    public String getPhotoUrl() {
+        return photoUrl;
+    }
+  }
+  
 
   /**
    * Gets user info from GITkit service using Gitkit token. Can be used to verify a Gitkit token

--- a/src/main/java/com/google/identitytoolkit/GitkitClient.java
+++ b/src/main/java/com/google/identitytoolkit/GitkitClient.java
@@ -183,22 +183,22 @@ public class GitkitClient {
    * @param email The email of the user
    * @param password The password inputed by the user
    * @param pendingIdToken The GITKit token for the non-trusted IDP, which is to be confirmed by the user
+   * @param captchaResponse Response to the captcha
    * @return Gitkit user if password is valid.
    * @throws GitkitClientException for invalid request
    * @throws GitkitServerException for server error
    */
-  public GitkitUser verifyPassword(String email, String password, String pendingIdToken)
+  public GitkitUser verifyPassword(String email, String password, String pendingIdToken, String captchaResponse)
       throws GitkitClientException, GitkitServerException {
     try {
-      JSONObject result = rpcHelper.verifyPassword(email, password, pendingIdToken);
+      JSONObject result = rpcHelper.verifyPassword(email, password, pendingIdToken, captchaResponse);
       return jsonToUser(result);
-
     } catch (JSONException e) {
       throw new GitkitServerException(e);
     }
   }
   
-    /**
+  /**
    * Verifies the user entered password at Gitkit server.
    *
    * @param email The email of the user
@@ -209,8 +209,7 @@ public class GitkitClient {
    */
   public GitkitUser verifyPassword(String email, String password)
       throws GitkitClientException, GitkitServerException {
-
-      return verifyPassword(email, password, null);
+      return verifyPassword(email, password, null, null);
   }
 
   /**

--- a/src/main/java/com/google/identitytoolkit/GitkitClient.java
+++ b/src/main/java/com/google/identitytoolkit/GitkitClient.java
@@ -176,7 +176,7 @@ public class GitkitClient {
     }
     return null;
   }
-  
+
   /**
    * Verifies the user entered password at Gitkit server.
    *
@@ -197,7 +197,7 @@ public class GitkitClient {
       throw new GitkitServerException(e);
     }
   }
-  
+
   /**
    * Verifies the user entered password at Gitkit server.
    *

--- a/src/main/java/com/google/identitytoolkit/GitkitClient.java
+++ b/src/main/java/com/google/identitytoolkit/GitkitClient.java
@@ -183,72 +183,35 @@ public class GitkitClient {
    * @param email The email of the user
    * @param password The password inputed by the user
    * @param pendingIdToken The GITKit token for the non-trusted IDP, which is to be confirmed by the user
-   * @param captchaChallenge The captcha challenge
-   * @param captchaResponse Response to the captcha
-   * @return the verify password response.
+   * @return Gitkit user if password is valid.
    * @throws GitkitClientException for invalid request
    * @throws GitkitServerException for server error
    */
-  public VerifyPasswordResponse verifyPassword(String email, String password, String pendingIdToken,
-                                               String captchaChallenge, String captchaResponse)
+  public GitkitUser verifyPassword(String email, String password, String pendingIdToken)
       throws GitkitClientException, GitkitServerException {
     try {
-      JSONObject result = rpcHelper.verifyPassword(email, password, pendingIdToken, captchaChallenge, captchaResponse);
-      return new VerifyPasswordResponse(result.getString("localId"), result.getString("email"),
-                                        result.getString("displayName"), result.getString("idToken"),
-                                        result.getBoolean("registered"), result.getString("photoUrl"));
+      JSONObject result = rpcHelper.verifyPassword(email, password, pendingIdToken);
+      return jsonToUser(result);
+
     } catch (JSONException e) {
       throw new GitkitServerException(e);
     }
   }
-
-  /**
-   * Wrapper class containing the verify password responses.
-   */
-  public class VerifyPasswordResponse {
-    private final String localId;
-    private final String email;
-    private final String displayName;
-    private final String idToken;
-    private final boolean registered;
-    private final String photoUrl;
-
-    public VerifyPasswordResponse(String localId, String email, String displayName, String idToken,
-                                  boolean registered, String photoUrl)
-    {
-        this.localId = localId;
-        this.email = email;
-        this.displayName = displayName;
-        this.idToken = idToken;
-        this.registered = registered;
-        this.photoUrl = photoUrl;
-    }
-
-    public String getLocalId() {
-        return localId;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public String getIdToken() {
-        return idToken;
-    }
-
-    public boolean isRegistered() {
-        return registered;
-    }
-
-    public String getPhotoUrl() {
-        return photoUrl;
-    }
-  }
   
+    /**
+   * Verifies the user entered password at Gitkit server.
+   *
+   * @param email The email of the user
+   * @param password The password inputed by the user
+   * @return Gitkit user if password is valid.
+   * @throws GitkitClientException for invalid request
+   * @throws GitkitServerException for server error
+   */
+  public GitkitUser verifyPassword(String email, String password)
+      throws GitkitClientException, GitkitServerException {
+
+      return verifyPassword(email, password, null);
+  }
 
   /**
    * Gets user info from GITkit service using Gitkit token. Can be used to verify a Gitkit token

--- a/src/main/java/com/google/identitytoolkit/RpcHelper.java
+++ b/src/main/java/com/google/identitytoolkit/RpcHelper.java
@@ -98,28 +98,21 @@ public class RpcHelper {
     }
   }
   
-  public JSONObject verifyPassword(String email, String password, String pendingIdToken,
-                                   String captchaChallenge, String captchaResponse)
+  public JSONObject verifyPassword(String email, String password, String pendingIdToken)
       throws GitkitServerException, GitkitClientException {
     try {
       JSONObject params = new JSONObject()
           .put("email", email)
           .put("password", password);
+
       if (pendingIdToken != null) {
         params.put("pendingIdToken", pendingIdToken);
-      }
-      if (captchaChallenge != null) {
-        params.put("captchaChallenge", captchaChallenge);
-      }
-      if (captchaResponse != null) {
-        params.put("captchaResponse", captchaResponse);
       }
       return invokeGoogle2LegOauthApi("verifyPassword", params);
     } catch (JSONException e) {
       throw new GitkitServerException(e);
     }
   }
-  
 
   public JSONObject getOobCode(JSONObject resetReq)
       throws GitkitClientException, GitkitServerException {

--- a/src/main/java/com/google/identitytoolkit/RpcHelper.java
+++ b/src/main/java/com/google/identitytoolkit/RpcHelper.java
@@ -98,15 +98,17 @@ public class RpcHelper {
     }
   }
   
-  public JSONObject verifyPassword(String email, String password, String pendingIdToken)
+  public JSONObject verifyPassword(String email, String password, String pendingIdToken, String captchaResponse)
       throws GitkitServerException, GitkitClientException {
     try {
       JSONObject params = new JSONObject()
           .put("email", email)
           .put("password", password);
-
       if (pendingIdToken != null) {
         params.put("pendingIdToken", pendingIdToken);
+      }
+      if (captchaResponse != null) {
+        params.put("captchaResponse", captchaResponse);
       }
       return invokeGoogle2LegOauthApi("verifyPassword", params);
     } catch (JSONException e) {

--- a/src/main/java/com/google/identitytoolkit/RpcHelper.java
+++ b/src/main/java/com/google/identitytoolkit/RpcHelper.java
@@ -97,6 +97,29 @@ public class RpcHelper {
       throw new GitkitServerException(e);
     }
   }
+  
+  public JSONObject verifyPassword(String email, String password, String pendingIdToken,
+                                   String captchaChallenge, String captchaResponse)
+      throws GitkitServerException, GitkitClientException {
+    try {
+      JSONObject params = new JSONObject()
+          .put("email", email)
+          .put("password", password);
+      if (pendingIdToken != null) {
+        params.put("pendingIdToken", pendingIdToken);
+      }
+      if (captchaChallenge != null) {
+        params.put("captchaChallenge", captchaChallenge);
+      }
+      if (captchaResponse != null) {
+        params.put("captchaResponse", captchaResponse);
+      }
+      return invokeGoogle2LegOauthApi("verifyPassword", params);
+    } catch (JSONException e) {
+      throw new GitkitServerException(e);
+    }
+  }
+  
 
   public JSONObject getOobCode(JSONObject resetReq)
       throws GitkitClientException, GitkitServerException {


### PR DESCRIPTION
The Identity API provides "verifyPassword" method. However, GitkitClient java class doesn't support it. It will be very useful to have it.