### PR TITLE
Move JUnit/Mockito dependencies to test scope.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,13 +138,13 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.9.5</version>
-      <scope>compile</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>
-      <scope>compile</scope>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Let's not impose JUnit and Mockito dependencies on everyone since they're only used in the test suite.