### PR TITLE
added proxy capability to the client

### DIFF
--- a/src/main/java/com/google/identitytoolkit/GitkitClient.java
+++ b/src/main/java/com/google/identitytoolkit/GitkitClient.java
@@ -107,20 +107,20 @@ public class GitkitClient {
      */
   public static GitkitClient createFromJson(String configPath, Proxy proxy) throws JSONException, IOException {
     JSONObject configData =
-                new JSONObject(
-                        StandardCharsets.UTF_8.decode(
-                                ByteBuffer.wrap(Files.readAllBytes(Paths.get(configPath))))
-                                .toString());
+        new JSONObject(
+            StandardCharsets.UTF_8.decode(
+                ByteBuffer.wrap(Files.readAllBytes(Paths.get(configPath))))
+                .toString());
 
     return new GitkitClient.Builder()
-                .setProxy(proxy)
-                .setGoogleClientId(configData.getString("clientId"))
-                .setServiceAccountEmail(configData.getString("serviceAccountEmail"))
-                .setKeyStream(new FileInputStream(configData.getString("serviceAccountPrivateKeyFile")))
-                .setWidgetUrl(configData.getString("widgetUrl"))
-                .setCookieName(configData.getString("cookieName"))
-                .setServerApiKey(configData.optString("serverApiKey", null))
-                .build();
+         .setProxy(proxy)
+         .setGoogleClientId(configData.getString("clientId"))
+         .setServiceAccountEmail(configData.getString("serviceAccountEmail"))
+         .setKeyStream(new FileInputStream(configData.getString("serviceAccountPrivateKeyFile")))
+         .setWidgetUrl(configData.getString("widgetUrl"))
+         .setCookieName(configData.getString("cookieName"))
+         .setServerApiKey(configData.optString("serverApiKey", null))
+         .build();
   }
 
   /**

--- a/src/main/java/com/google/identitytoolkit/GitkitClient.java
+++ b/src/main/java/com/google/identitytoolkit/GitkitClient.java
@@ -96,20 +96,7 @@ public class GitkitClient {
    * @return Gitkit client
    */
   public static GitkitClient createFromJson(String configPath) throws JSONException, IOException {
-    JSONObject configData =
-        new JSONObject(
-            StandardCharsets.UTF_8.decode(
-                ByteBuffer.wrap(Files.readAllBytes(Paths.get(configPath))))
-                .toString());
-
-    return new GitkitClient.Builder()
-         .setGoogleClientId(configData.getString("clientId"))
-         .setServiceAccountEmail(configData.getString("serviceAccountEmail"))
-         .setKeyStream(new FileInputStream(configData.getString("serviceAccountPrivateKeyFile")))
-         .setWidgetUrl(configData.getString("widgetUrl"))
-         .setCookieName(configData.getString("cookieName"))
-         .setServerApiKey(configData.optString("serverApiKey", null))
-         .build();
+    return createFromJson(configPath, null);
   }
 
     /**
@@ -118,14 +105,15 @@ public class GitkitClient {
      * @param configPath Path to JSON configuration file
      * @return Gitkit client
      */
-    public static GitkitClient createFromJson(String configPath, Proxy proxy) throws JSONException, IOException {
-        JSONObject configData =
+  public static GitkitClient createFromJson(String configPath, Proxy proxy) throws JSONException, IOException {
+    JSONObject configData =
                 new JSONObject(
                         StandardCharsets.UTF_8.decode(
                                 ByteBuffer.wrap(Files.readAllBytes(Paths.get(configPath))))
                                 .toString());
 
-        return new GitkitClient.Builder(proxy)
+    return new GitkitClient.Builder()
+                .setProxy(proxy)
                 .setGoogleClientId(configData.getString("clientId"))
                 .setServiceAccountEmail(configData.getString("serviceAccountEmail"))
                 .setKeyStream(new FileInputStream(configData.getString("serviceAccountPrivateKeyFile")))
@@ -133,7 +121,7 @@ public class GitkitClient {
                 .setCookieName(configData.getString("cookieName"))
                 .setServerApiKey(configData.optString("serverApiKey", null))
                 .build();
-    }
+  }
 
   /**
    * Verifies a Gitkit token.
@@ -604,19 +592,16 @@ public class GitkitClient {
    */
   public static class Builder {
     private String clientId;
-    private HttpSender httpSender;
+    private HttpSender httpSender = new HttpSender();
     private String widgetUrl;
     private String serviceAccountEmail;
     private InputStream keyStream;
     private String serverApiKey;
     private String cookieName = "gtoken";
 
-    public  Builder(Proxy proxy) {
-      httpSender = new HttpSender(proxy);
-    }
-
-    public  Builder() {
-      httpSender = new HttpSender();
+    public Builder setProxy(Proxy proxy) {
+      this.httpSender = new HttpSender(proxy);
+      return this;
     }
 
     public Builder setGoogleClientId(String clientId) {

--- a/src/main/java/com/google/identitytoolkit/GitkitClient.java
+++ b/src/main/java/com/google/identitytoolkit/GitkitClient.java
@@ -103,6 +103,7 @@ public class GitkitClient {
      * Constructs a Gitkit client from a JSON config file
      *
      * @param configPath Path to JSON configuration file
+     * @param proxy the Proxy object to use when using Gitkit client behind a proxy
      * @return Gitkit client
      */
   public static GitkitClient createFromJson(String configPath, Proxy proxy) throws JSONException, IOException {

--- a/src/main/java/com/google/identitytoolkit/GitkitClient.java
+++ b/src/main/java/com/google/identitytoolkit/GitkitClient.java
@@ -31,6 +31,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.Proxy;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -110,6 +111,29 @@ public class GitkitClient {
          .setServerApiKey(configData.optString("serverApiKey", null))
          .build();
   }
+
+    /**
+     * Constructs a Gitkit client from a JSON config file
+     *
+     * @param configPath Path to JSON configuration file
+     * @return Gitkit client
+     */
+    public static GitkitClient createFromJson(String configPath, Proxy proxy) throws JSONException, IOException {
+        JSONObject configData =
+                new JSONObject(
+                        StandardCharsets.UTF_8.decode(
+                                ByteBuffer.wrap(Files.readAllBytes(Paths.get(configPath))))
+                                .toString());
+
+        return new GitkitClient.Builder(proxy)
+                .setGoogleClientId(configData.getString("clientId"))
+                .setServiceAccountEmail(configData.getString("serviceAccountEmail"))
+                .setKeyStream(new FileInputStream(configData.getString("serviceAccountPrivateKeyFile")))
+                .setWidgetUrl(configData.getString("widgetUrl"))
+                .setCookieName(configData.getString("cookieName"))
+                .setServerApiKey(configData.optString("serverApiKey", null))
+                .build();
+    }
 
   /**
    * Verifies a Gitkit token.
@@ -580,12 +604,20 @@ public class GitkitClient {
    */
   public static class Builder {
     private String clientId;
-    private HttpSender httpSender = new HttpSender();
+    private HttpSender httpSender;
     private String widgetUrl;
     private String serviceAccountEmail;
     private InputStream keyStream;
     private String serverApiKey;
     private String cookieName = "gtoken";
+
+    public  Builder(Proxy proxy) {
+      httpSender = new HttpSender(proxy);
+    }
+
+    public  Builder() {
+      httpSender = new HttpSender();
+    }
 
     public Builder setGoogleClientId(String clientId) {
       this.clientId = clientId;

--- a/src/main/java/com/google/identitytoolkit/HttpSender.java
+++ b/src/main/java/com/google/identitytoolkit/HttpSender.java
@@ -23,6 +23,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.Proxy;
 import java.net.URL;
 import java.util.Map;
 
@@ -32,6 +33,13 @@ import java.util.Map;
 public class HttpSender {
 
   private static final String USER_AGENT = "GitkitJavaClient/1.0";
+  private Proxy proxy = null;
+
+  HttpSender() {}
+
+  HttpSender(Proxy proxy) {
+        this.proxy = proxy;
+    }
 
   /**
    * Sends a HTTP Get request.
@@ -60,7 +68,12 @@ public class HttpSender {
   private String doHttpTransfer(String url, String data, Map<String, String> headers)
       throws IOException{
     try {
-      HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+      HttpURLConnection connection;
+      if(proxy == null)
+        connection = (HttpURLConnection) new URL(url).openConnection();
+      else
+        connection = (HttpURLConnection) new URL(url).openConnection(proxy);
+
       for (Map.Entry<String, String> header : headers.entrySet()) {
         connection.setRequestProperty(header.getKey(), header.getValue());
       }


### PR DESCRIPTION
Identity client doesn´t  allow the user to use the library behind a proxy. This does not happen in libraries like the Java client for Google sign-in in which you can set the proxy via NetHttpTransport.
Therefore it would be really usefull to merge this branch in which you can set your proxy with:
`Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(host, port));`
`GitkitClient gitkitClient = GitkitClient.createFromJson("conf/gitkit-server-config.json",proxy);`