### PR TITLE
Changed tomcat-servlet-api to provided scope and removed redundant compile scope def

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,37 +78,31 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>16.0.1</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.6</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.0</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-core-asl</artifactId>
       <version>1.9.13</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20140107</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.googlecode.jsontoken</groupId>
       <artifactId>jsontoken</artifactId>
       <version>1.1</version>
-      <scope>compile</scope>
       <exclusions>
         <exclusion>
           <groupId>com.google.collections</groupId>
@@ -120,19 +114,18 @@
       <groupId>net.sf.jsr107cache</groupId>
       <artifactId>jsr107cache</artifactId>
       <version>1.1</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
       <version>2.0</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-servlet-api</artifactId>
       <version>8.0.12</version>
       <type>jar</type>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
identity-toolkit-java-client is used in a web container environment which should already provide the servlet API, so the scope for tomcat-servlet-api can be set to provided instead to avoid being pulled in as an extra packaging dependency.

Also removed the compile scope definitions from dependencies as not specifying a scope already implies a compile scope.