### PR TITLE
Replaced Json with Gson to rid of its dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,6 @@
       <version>1.9.13</version>
     </dependency>
     <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>20140107</version>
-    </dependency>
-    <dependency>
       <groupId>com.googlecode.jsontoken</groupId>
       <artifactId>jsontoken</artifactId>
       <version>1.1</version>

--- a/src/main/java/com/google/identitytoolkit/GitkitUser.java
+++ b/src/main/java/com/google/identitytoolkit/GitkitUser.java
@@ -16,15 +16,14 @@
 
 package com.google.identitytoolkit;
 
-import com.google.common.collect.Lists;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 /**
  * Wrapper class containing user attributes.
@@ -88,23 +87,25 @@ public class GitkitUser {
     return providers;
   }
 
-  public GitkitUser setProviders(JSONArray providers) throws JSONException {
+  public GitkitUser setProviders(JsonArray providers) {
     List<ProviderInfo> providerInfo = new ArrayList<ProviderInfo>();
     if (providers != null) {
-      for (int i = 0; i < providers.length(); i++) {
-        JSONObject provider = providers.getJSONObject(i);
+      for (int i = 0; i < providers.size(); i++) {
+        JsonObject provider = providers.get(i).getAsJsonObject();
+        JsonElement displayNameElement = provider.get("displayName");
+        JsonElement photoUrlElement = provider.get("photoUrl");
         providerInfo.add(new ProviderInfo(
-            provider.getString("providerId"),
-            provider.getString("federatedId"),
-            provider.optString("displayName"),
-            provider.optString("photoUrl")));
+            provider.get("providerId").getAsString(),
+            provider.get("federatedId").getAsString(),
+            (displayNameElement == null) ? "" : displayNameElement.getAsString(),
+            (photoUrlElement == null) ? "" : photoUrlElement.getAsString()));
       }
     }
     this.providers = providerInfo;
     return this;
   }
 
-  public GitkitUser setProviders(List<ProviderInfo> providers) throws JSONException {
+  public GitkitUser setProviders(List<ProviderInfo> providers) {
     this.providers.clear();
     this.providers.addAll(providers);
     return this;

--- a/src/main/java/com/google/identitytoolkit/JsonTokenHelper.java
+++ b/src/main/java/com/google/identitytoolkit/JsonTokenHelper.java
@@ -16,7 +16,6 @@
 
 package com.google.identitytoolkit;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;


### PR DESCRIPTION
Per issue #33, I have replaced Json usages with that of Gson. However I have some concerns:

1. Since JSONException references have to be removed, it had to be removed from numerous method signatures.
2. Gson throws RuntimExceptions instead of Exceptions on object type incompatibility. This changes some exception handling behaviour vs. Json which uses JSONException. The updated code will just let RuntimeExceptions trickle up.
3. Gson API is not fluent and requires more chained calls.

Please review and see if these are OK when reviewing the pull request. If it's too much risk we can leave the original code alone. Thanks.